### PR TITLE
fix: Fixing the device configs for a few devices

### DIFF
--- a/buttplug-device-config.yml
+++ b/buttplug-device-config.yml
@@ -187,7 +187,8 @@ protocols:
         - Magic Wand
         - Krush
       services:
-        78667579-7b48-43db-b8c5-7928a6b0a335: null
+        78667579-7b48-43db-b8c5-7928a6b0a335:
+          tx: 78667579-a914-49a4-8333-aa3c0cd8fedc
   mysteryvibe:
     btle:
       names:
@@ -210,7 +211,8 @@ protocols:
         - Egg driver
         - Surfer_plug
       services:
-        0000fff0-0000-1000-8000-00805f9b34fb: null
+        0000fff0-0000-1000-8000-00805f9b34fb:
+          tx: 0000fff1-0000-1000-8000-00805f9b34fb
   vibratissimo:
     btle:
       names:
@@ -240,7 +242,9 @@ protocols:
         - Verge
         - Wish
       services:
-        f000bb03-0451-4000-b000-000000000000: null
+        f000bb03-0451-4000-b000-000000000000:
+          tx: f000c000-0451-4000-b000-000000000000
+          rx: f000b000-0451-4000-b000-000000000000
   youcups:
     btle:
       names:
@@ -272,6 +276,7 @@ protocols:
     btle:
       names:
         - Launch
+        - Onyx2
       services:
         88f80580-0000-01e6-aace-0002a5d5c51b:
           tx: 88f80581-0000-01e6-aace-0002a5d5c51b
@@ -279,6 +284,12 @@ protocols:
           # The Launch has a special characteristic for loading
           # firmware.
           firmware: 88f80583-0000-01e6-aace-0002a5d5c51b
+        f60402a6-0293-4bdb-9f20-6758133f7090:
+          tx: 02962ac9-e86f-4094-989d-231d69995fc2
+          rx: d44d0393-0731-43b3-a373-8fc70b1f3323
+          # The Onyx2 has a special characteristic for loading
+          # firmware.
+          firmware: c7b7a04b-2cc4-40ff-8b10-5d531d1161db
   erostek-et312:
     serial:
       # Port names are defined in user configs
@@ -303,7 +314,7 @@ protocols:
         49535343-fe7d-4ae5-8fa9-9fafd205e455:
           rx: 49535343-1e4d-4bd9-ba61-23c647249616
           tx: 49535343-8841-43f4-a8d4-ecbe34729bb3
-          cmd: 49535343-aca3-481c-91ec-d85e28a60318
+          command: 49535343-aca3-481c-91ec-d85e28a60318
           cmd2: 49535343-6daa-4d02-abf6-19569aca69fe
   vorze-sa:
     btle:
@@ -312,7 +323,8 @@ protocols:
         - Bach smart
         - UFOSA
       services:
-        40ee1111-63ec-4b7f-8ce7-712efd55b90e: null
+        40ee1111-63ec-4b7f-8ce7-712efd55b90e:
+          tx: 40ee2222-63ec-4b7f-8ce7-712efd55b90e
   # nintendo-joycon:
   #   names:
   #     en-us: Nintendo Joycon


### PR DESCRIPTION
Corrected devices are:
- ONYX
- Onyx2
- Vibratisimo (DuoBalls testsed)
- Picobong (Diver tested)
- MagicMotion (MagicWand, Flamingo and MagicCell tested)
- WeVibe (Pivot and Verge tested)
- Vorze (Bach tested)