### PR TITLE
fix: Correcting the Vorze Cyclone name

### DIFF
--- a/buttplug-device-config.yml
+++ b/buttplug-device-config.yml
@@ -361,7 +361,7 @@ protocols:
   vorze-sa:
     btle:
       names:
-        - CYCSA
+        - CycSA
         - Bach smart
         - UFOSA
       services:
@@ -383,9 +383,9 @@ protocols:
       names:
         - Aogu BLE *
       services:
-        0000FFE5-0000-1000-8000-00805f9b34fb:
-          tx: 0000FFE9-0000-1000-8000-00805f9b34fb
-          rx: 0000FFE2-0000-1000-8000-00805f9b34fb
+        0000ffe5-0000-1000-8000-00805f9b34fb:
+          tx: 0000ffe9-0000-1000-8000-00805f9b34fb
+          rx: 0000ffe2-0000-1000-8000-00805f9b34fb
   # nintendo-joycon:
   #   hid:
   #     vendor-id: 0x057e


### PR DESCRIPTION
Fixes #3

Somehow I managed to pick up some additional downcasing when moving between repos.
According to the previous commit, the change is valid, so I'm leaving that diff in.